### PR TITLE
eliminate Analyze warning.

### DIFF
--- a/FBNetworkReachability.m
+++ b/FBNetworkReachability.m
@@ -64,7 +64,9 @@
 - (void) dealloc
 {
     [self stopNotifier];
-	CFRelease(reachability_);
+	if (reachability_) {
+		CFRelease(reachability_);
+	}
 	[super dealloc];
 }
 


### PR DESCRIPTION
Thank you for good library.

'Analyze' command on Xcode 4.6.1 shows 'NULL pointer argument in call to CFRelease' warning, so the patch just eliminates it.
